### PR TITLE
supports spot fleet from docker-machine

### DIFF
--- a/README.md
+++ b/README.md
@@ -369,6 +369,45 @@ module "runner" {
 }
 ```
 
+### Scenario: Use of Spot Fleet
+
+Since spot instances can be taken over by AWS depending on the instance type and AZ you are using, yu may want multiple instances types in multiple AZs. This is where spot fleets come in, when there is no capacity on one instance type and one AZ, AWS will take the next instance type and so on. This update has been possible since [docker-machine](https://gitlab.com/cki-project/docker-machine/-/tree/v0.16.2-gitlab.19-cki.2) supports spot fleets.
+
+```hcl
+module "runner" {
+  # https://registry.terraform.io/modules/npalm/gitlab-runner/aws/
+  source  = "npalm/gitlab-runner/aws"
+
+  aws_region  = "eu-west-3"
+  environment = "spot-runners"
+
+  vpc_id                   = module.vpc.vpc_id
+  subnet_ids               = module.vpc.private_subnets
+
+  docker_machine_instance_types             = ["t3a.medium", "t3.medium", "c5a.large"]
+  use_fleet                                 = true
+  public_key                                = "<ssh-public-key>"
+  secure_parameter_store_runner_private_key = "<parameter-store-key-name>"
+  key_pair_name                             = "<key_pair_name>
+
+  runners_name       = "docker-machine"
+  runners_gitlab_url = "https://gitlab.com"
+
+  gitlab_runner_registration_config = {
+    registration_token = "my-token"
+    tag_list           = "docker"
+    description        = "runner default"
+    locked_to_project  = "true"
+    run_untagged       = "false"
+    maximum_timeout    = "3600"
+  }
+
+  overrides = {
+    name_iam_objects = "<region-specific-prefix>-gitlab-runner-iam"
+  }
+}
+```
+
 ## Examples
 
 A few [examples](https://github.com/npalm/terraform-aws-gitlab-runner/tree/main/examples/) are provided. Use the
@@ -438,7 +477,7 @@ Made with [contributors-img](https://contrib.rocks).
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 4.49.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4 |
 | <a name="provider_local"></a> [local](#provider\_local) | >= 2.4.0 |
 
 ## Modules
@@ -477,9 +516,11 @@ Made with [contributors-img](https://contrib.rocks).
 | [aws_iam_role_policy_attachment.service_linked_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_iam_role_policy_attachment.ssm](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_iam_role_policy_attachment.user_defined_policies](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
+| [aws_key_pair.fleet_key](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/key_pair) | resource |
 | [aws_kms_alias.default](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/kms_alias) | resource |
 | [aws_kms_key.default](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/kms_key) | resource |
 | [aws_launch_template.gitlab_runner_instance](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/launch_template) | resource |
+| [aws_launch_template.gitlab_runners](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/launch_template) | resource |
 | [aws_security_group.docker_machine](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group) | resource |
 | [aws_security_group.runner](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group) | resource |
 | [aws_security_group_rule.docker_machine_docker_runner](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
@@ -535,6 +576,7 @@ Made with [contributors-img](https://contrib.rocks).
 | <a name="input_docker_machine_iam_policy_arns"></a> [docker\_machine\_iam\_policy\_arns](#input\_docker\_machine\_iam\_policy\_arns) | List of policy ARNs to be added to the instance profile of the docker machine runners. | `list(string)` | `[]` | no |
 | <a name="input_docker_machine_instance_metadata_options"></a> [docker\_machine\_instance\_metadata\_options](#input\_docker\_machine\_instance\_metadata\_options) | Enable the docker machine instances metadata service. Requires you use GitLab maintained docker machines. | <pre>object({<br>    http_tokens                 = string<br>    http_put_response_hop_limit = number<br>  })</pre> | <pre>{<br>  "http_put_response_hop_limit": 2,<br>  "http_tokens": "required"<br>}</pre> | no |
 | <a name="input_docker_machine_instance_type"></a> [docker\_machine\_instance\_type](#input\_docker\_machine\_instance\_type) | Instance type used for the instances hosting docker-machine. | `string` | `"m5.large"` | no |
+| <a name="input_docker_machine_instance_types"></a> [docker\_machine\_instance\_types](#input\_docker\_machine\_instance\_types) | Instance types used for the instances hosting docker-machine. This variable is only supported when use\_fleet is set to true. | `list(string)` | `[]` | no |
 | <a name="input_docker_machine_options"></a> [docker\_machine\_options](#input\_docker\_machine\_options) | List of additional options for the docker machine config. Each element of this list must be a key=value pair. E.g. '["amazonec2-zone=a"]' | `list(string)` | `[]` | no |
 | <a name="input_docker_machine_role_json"></a> [docker\_machine\_role\_json](#input\_docker\_machine\_role\_json) | Docker machine runner instance override policy, expected to be in JSON format. | `string` | `""` | no |
 | <a name="input_docker_machine_security_group_description"></a> [docker\_machine\_security\_group\_description](#input\_docker\_machine\_security\_group\_description) | A description for the docker-machine security group | `string` | `"A security group containing docker-machine instances"` | no |
@@ -559,6 +601,7 @@ Made with [contributors-img](https://contrib.rocks).
 | <a name="input_gitlab_runner_version"></a> [gitlab\_runner\_version](#input\_gitlab\_runner\_version) | Version of the [GitLab runner](https://gitlab.com/gitlab-org/gitlab-runner/-/releases). | `string` | `"15.8.2"` | no |
 | <a name="input_instance_role_json"></a> [instance\_role\_json](#input\_instance\_role\_json) | Default runner instance override policy, expected to be in JSON format. | `string` | `""` | no |
 | <a name="input_instance_type"></a> [instance\_type](#input\_instance\_type) | Instance type used for the GitLab runner. | `string` | `"t3.micro"` | no |
+| <a name="input_key_pair_name"></a> [key\_pair\_name](#input\_key\_pair\_name) | The name of the key pair used by the runner to connect to the docker-machine executors. | `string` | `"fleet-key"` | no |
 | <a name="input_kms_alias_name"></a> [kms\_alias\_name](#input\_kms\_alias\_name) | Alias added to the kms\_key (if created and not provided by kms\_key\_id) | `string` | `""` | no |
 | <a name="input_kms_deletion_window_in_days"></a> [kms\_deletion\_window\_in\_days](#input\_kms\_deletion\_window\_in\_days) | Key rotation window, set to 0 for no rotation. Only used when `enable_kms` is set to `true`. | `number` | `7` | no |
 | <a name="input_kms_key_id"></a> [kms\_key\_id](#input\_kms\_key\_id) | KMS key id to encrypted the resources. Ensure CloudWatch and Runner/Executor have access to the provided KMS key. | `string` | `""` | no |
@@ -567,6 +610,7 @@ Made with [contributors-img](https://contrib.rocks).
 | <a name="input_overrides"></a> [overrides](#input\_overrides) | This map provides the possibility to override some defaults.<br>The following attributes are supported:<br>  * `name_sg` set the name prefix and overwrite the `Name` tag for all security groups created by this module.<br>  * `name_runner_agent_instance` set the name prefix and override the `Name` tag for the EC2 gitlab runner instances defined in the auto launch configuration.<br>  * `name_docker_machine_runners` override the `Name` tag of EC2 instances created by the runner agent (used as name prefix for `docker_machine_version` >= 0.16.2).<br>  * `name_iam_objects` set the name prefix of all AWS IAM resources created by this module. | `map(string)` | <pre>{<br>  "name_docker_machine_runners": "",<br>  "name_iam_objects": "",<br>  "name_runner_agent_instance": "",<br>  "name_sg": ""<br>}</pre> | no |
 | <a name="input_permissions_boundary"></a> [permissions\_boundary](#input\_permissions\_boundary) | Name of permissions boundary policy to attach to AWS IAM roles | `string` | `""` | no |
 | <a name="input_prometheus_listen_address"></a> [prometheus\_listen\_address](#input\_prometheus\_listen\_address) | Defines an address (<host>:<port>) the Prometheus metrics HTTP server should listen on. | `string` | `""` | no |
+| <a name="input_public_key"></a> [public\_key](#input\_public\_key) | The SSH public key used by the runner to connect to the docker-machine executors. This variable is supported only when use\_fleet is set to true. | `string` | `""` | no |
 | <a name="input_role_tags"></a> [role\_tags](#input\_role\_tags) | Map of tags that will be added to the role created. Useful for tag based authorization. | `map(string)` | `{}` | no |
 | <a name="input_runner_agent_uses_private_address"></a> [runner\_agent\_uses\_private\_address](#input\_runner\_agent\_uses\_private\_address) | Restrict the runner agent to the use of a private IP address. If `runner_agent_uses_private_address` is set to `false` it will override the `runners_use_private_address` for the agent. | `bool` | `true` | no |
 | <a name="input_runner_ami_filter"></a> [runner\_ami\_filter](#input\_runner\_ami\_filter) | List of maps used to create the AMI filter for the Gitlab runner docker-machine AMI. | `map(list(string))` | <pre>{<br>  "name": [<br>    "ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-*"<br>  ]<br>}</pre> | no |
@@ -626,15 +670,18 @@ Made with [contributors-img](https://contrib.rocks).
 | <a name="input_runners_volume_type"></a> [runners\_volume\_type](#input\_runners\_volume\_type) | Runner instance volume type | `string` | `"gp2"` | no |
 | <a name="input_runners_volumes_tmpfs"></a> [runners\_volumes\_tmpfs](#input\_runners\_volumes\_tmpfs) | Mount a tmpfs in runner container. https://docs.gitlab.com/runner/executors/docker.html#mounting-a-directory-in-ram | <pre>list(object({<br>    volume  = string<br>    options = string<br>  }))</pre> | `[]` | no |
 | <a name="input_schedule_config"></a> [schedule\_config](#input\_schedule\_config) | Map containing the configuration of the ASG scale-out and scale-in for the runner instance. Will only be used if enable\_schedule is set to true. | `map(any)` | <pre>{<br>  "scale_in_count": 0,<br>  "scale_in_recurrence": "0 18 * * 1-5",<br>  "scale_in_time_zone": "Etc/UTC",<br>  "scale_out_count": 1,<br>  "scale_out_recurrence": "0 8 * * 1-5",<br>  "scale_out_time_zone": "Etc/UTC"<br>}</pre> | no |
+| <a name="input_secure_parameter_store_runner_private_key"></a> [secure\_parameter\_store\_runner\_private\_key](#input\_secure\_parameter\_store\_runner\_private\_key) | The key name used to store the Gitlab runner private key in Secure Parameter Store | `string` | `""` | no |
 | <a name="input_secure_parameter_store_runner_sentry_dsn"></a> [secure\_parameter\_store\_runner\_sentry\_dsn](#input\_secure\_parameter\_store\_runner\_sentry\_dsn) | The Sentry DSN name used to store the Sentry DSN in Secure Parameter Store | `string` | `"sentry-dsn"` | no |
 | <a name="input_secure_parameter_store_runner_token_key"></a> [secure\_parameter\_store\_runner\_token\_key](#input\_secure\_parameter\_store\_runner\_token\_key) | The key name used store the Gitlab runner token in Secure Parameter Store | `string` | `"runner-token"` | no |
 | <a name="input_sentry_dsn"></a> [sentry\_dsn](#input\_sentry\_dsn) | Sentry DSN of the project for the runner to use (uses legacy DSN format) | `string` | `"__SENTRY_DSN_REPLACED_BY_USER_DATA__"` | no |
 | <a name="input_show_user_data_in_plan"></a> [show\_user\_data\_in\_plan](#input\_show\_user\_data\_in\_plan) | When enabled, shows the diff for agent configuration files in Terraform plan: `config.toml` and user data script | `bool` | `false` | no |
 | <a name="input_subnet_id"></a> [subnet\_id](#input\_subnet\_id) | Subnet id used for the runner and executors. Must belong to the VPC specified above. | `string` | `""` | no |
 | <a name="input_subnet_id_runners"></a> [subnet\_id\_runners](#input\_subnet\_id\_runners) | Deprecated! Use subnet\_id instead. List of subnets used for hosting the gitlab-runners. | `string` | `""` | no |
+| <a name="input_subnet_ids"></a> [subnet\_ids](#input\_subnet\_ids) | First subnet in the list is used for the runner. Complete list is used for executors when the fleet mode is enabled. Must belong to the VPC specified above. | `list(string)` | `[]` | no |
 | <a name="input_subnet_ids_gitlab_runner"></a> [subnet\_ids\_gitlab\_runner](#input\_subnet\_ids\_gitlab\_runner) | Deprecated! Use subnet\_id instead. Subnet used for hosting the GitLab runner. | `list(string)` | `[]` | no |
 | <a name="input_suppressed_tags"></a> [suppressed\_tags](#input\_suppressed\_tags) | List of tag keys which are removed from tags, agent\_tags and runner\_tags and never added as default tag by the module. | `list(string)` | `[]` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | Map of tags that will be added to created resources. By default resources will be tagged with name and environment. | `map(string)` | `{}` | no |
+| <a name="input_use_fleet"></a> [use\_fleet](#input\_use\_fleet) | Use the fleet mode for agents. https://gitlab.com/cki-project/docker-machine/-/blob/v0.16.2-gitlab.19-cki.2/docs/drivers/aws.md#fleet-mode | `bool` | `false` | no |
 | <a name="input_userdata_post_install"></a> [userdata\_post\_install](#input\_userdata\_post\_install) | User-data script snippet to insert after GitLab runner install | `string` | `""` | no |
 | <a name="input_userdata_pre_install"></a> [userdata\_pre\_install](#input\_userdata\_pre\_install) | User-data script snippet to insert before GitLab runner install | `string` | `""` | no |
 | <a name="input_vpc_id"></a> [vpc\_id](#input\_vpc\_id) | The target VPC for the docker-machine and runner instances. | `string` | n/a | yes |

--- a/README.md
+++ b/README.md
@@ -371,8 +371,9 @@ module "runner" {
 
 ### Scenario: Use of Spot Fleet
 
-Since spot instances can be taken over by AWS depending on the instance type and AZ you are using, yu may want multiple instances types in multiple AZs. This is where spot fleets come in, when there is no capacity on one instance type and one AZ, AWS will take the next instance type and so on. This update has been possible since [docker-machine](https://gitlab.com/cki-project/docker-machine/-/tree/v0.16.2-gitlab.19-cki.2) supports spot fleets.
+Since spot instances can be taken over by AWS depending on the instance type and AZ you are using, you may want multiple instances types in multiple AZs. This is where spot fleets come in, when there is no capacity on one instance type and one AZ, AWS will take the next instance type and so on. This update has been possible since the [fork](https://gitlab.com/cki-project/docker-machine/-/tree/v0.16.2-gitlab.19-cki.2) of docker-machine supports spot fleets.
 
+#### Configuration example
 ```hcl
 module "runner" {
   # https://registry.terraform.io/modules/npalm/gitlab-runner/aws/
@@ -384,7 +385,7 @@ module "runner" {
   vpc_id                   = module.vpc.vpc_id
   subnet_ids               = module.vpc.private_subnets
 
-  docker_machine_instance_types             = ["t3a.medium", "t3.medium", "c5a.large"]
+  docker_machine_instance_types             = ["t3a.medium", "t3.medium", "t2.medium"]
   use_fleet                                 = true
   public_key                                = "<ssh-public-key>"
   secure_parameter_store_runner_private_key = "<parameter-store-key-name>"

--- a/locals.tf
+++ b/locals.tf
@@ -59,10 +59,6 @@ locals {
   secure_parameter_store_runner_token_key  = "${var.environment}-${var.secure_parameter_store_runner_token_key}"
   secure_parameter_store_runner_sentry_dsn = "${var.environment}-${var.secure_parameter_store_runner_sentry_dsn}"
 
-
-  # Custom name for runners
-  name_docker_machine_runners = var.overrides["name_docker_machine_runners"] == "" ? local.tags["Name"] : var.overrides["name_docker_machine_runners"]
-
   # Custom names for runner agent instance, security groups, and IAM objects
   name_runner_agent_instance = var.overrides["name_runner_agent_instance"] == "" ? local.tags["Name"] : var.overrides["name_runner_agent_instance"]
   name_sg                    = var.overrides["name_sg"] == "" ? local.tags["Name"] : var.overrides["name_sg"]

--- a/locals.tf
+++ b/locals.tf
@@ -59,6 +59,10 @@ locals {
   secure_parameter_store_runner_token_key  = "${var.environment}-${var.secure_parameter_store_runner_token_key}"
   secure_parameter_store_runner_sentry_dsn = "${var.environment}-${var.secure_parameter_store_runner_sentry_dsn}"
 
+
+  # Custom name for runners
+  name_docker_machine_runners = var.overrides["name_docker_machine_runners"] == "" ? local.tags["Name"] : var.overrides["name_docker_machine_runners"]
+
   # Custom names for runner agent instance, security groups, and IAM objects
   name_runner_agent_instance = var.overrides["name_runner_agent_instance"] == "" ? local.tags["Name"] : var.overrides["name_runner_agent_instance"]
   name_sg                    = var.overrides["name_sg"] == "" ? local.tags["Name"] : var.overrides["name_sg"]

--- a/main.tf
+++ b/main.tf
@@ -79,7 +79,6 @@ locals {
       gitlab_runner_access_level                   = lookup(var.gitlab_runner_registration_config, "access_level", "not_protected")
       sentry_dsn                                   = var.sentry_dsn
       public_key                                   = var.public_key
-      private_key                                  = var.private_key
       use_fleet                                    = var.use_fleet
   })
 
@@ -92,10 +91,10 @@ locals {
       runners_extra_hosts               = var.runners_extra_hosts
       runners_vpc_id                    = var.vpc_id
       runners_subnet_id                 = length(var.subnet_id) > 0 ? var.subnet_id : var.subnet_id_runners
-      runners_subnet_ids                = var.subnet_ids
+      runners_subnet_ids                = length(var.subnet_ids) > 0 ? var.subnet_ids : length(var.subnet_id) > 0 ? [var.subnet_id] : [var.subnet_id_runners]
       runners_aws_zone                  = data.aws_availability_zone.runners.name_suffix
       runners_instance_type             = var.docker_machine_instance_type
-      runners_instance_types            = var.docker_machine_instance_types
+      runners_instance_types            = length(var.docker_machine_instance_types) > 0 ?  var.docker_machine_instance_types : [var.docker_machine_instance_type]
       runners_spot_price_bid            = var.docker_machine_spot_price_bid == "on-demand-price" || var.docker_machine_spot_price_bid == null ? "" : var.docker_machine_spot_price_bid
       runners_ami                       = var.runners_executor == "docker+machine" ? data.aws_ami.docker-machine[0].id : ""
       runners_security_group_name       = var.runners_executor == "docker+machine" ? aws_security_group.docker_machine[0].name : ""
@@ -328,6 +327,8 @@ resource "aws_launch_template" "gitlab_runner_instance" {
 }
 
 resource "aws_key_pair" "fleet_key" {
+  count      = var.use_fleet == true && var.runners_executor == "docker+machine" ? 1 : 0
+
   key_name   = var.key_pair_name
   public_key = var.public_key
 }
@@ -336,23 +337,15 @@ resource "aws_launch_template" "gitlab_runners" {
   # checkov:skip=CKV_AWS_88:User can decide to add a public IP.
   # checkov:skip=CKV_AWS_79:User can decide to enable Metadata service V2. V2 is the default.
   count = var.use_fleet == true && var.runners_executor == "docker+machine" ? 1 : 0
-  name_prefix = "${local.name_docker_machine_runners}-agent-"
+  name_prefix = "${local.name_runner_agent_instance}-worker-"
 
-  key_name               = aws_key_pair.fleet_key.key_name
+  key_name               = aws_key_pair.fleet_key[0].key_name
   image_id               = data.aws_ami.docker-machine[0].id
   instance_type          = var.docker_machine_instance_types[0] # it will be overrided by the fleet
   update_default_version = true
-  monitoring {
-    enabled = var.runner_instance_enable_monitoring
-  }
-
-  iam_instance_profile {
-    name = local.aws_iam_role_instance_name
-  }
 
   network_interfaces {
-    security_groups             = concat([aws_security_group.docker_machine[0].id], var.extra_security_group_ids_runner_agent)
-    associate_public_ip_address = false == (var.runner_agent_uses_private_address == false ? var.runner_agent_uses_private_address : var.runners_use_private_address)
+    security_groups             = concat([aws_security_group.docker_machine[0].id])
   }
   tag_specifications {
     resource_type = "instance"
@@ -368,9 +361,6 @@ resource "aws_launch_template" "gitlab_runners" {
   lifecycle {
     create_before_destroy = true
   }
-
-  # otherwise the agent running on the EC2 instance tries to create the log group
-  depends_on = [aws_cloudwatch_log_group.environment]
 }
 
 ################################################################################

--- a/main.tf
+++ b/main.tf
@@ -341,16 +341,35 @@ resource "aws_launch_template" "gitlab_runners" {
 
   key_name               = aws_key_pair.fleet_key[0].key_name
   image_id               = data.aws_ami.docker-machine[0].id
+  user_data              = base64gzip(var.runners_userdata)
   instance_type          = var.docker_machine_instance_types[0] # it will be overrided by the fleet
   update_default_version = true
+  ebs_optimized          = var.runners_ebs_optimized
+  monitoring {
+    enabled = var.runners_monitoring
+  }
+  block_device_mappings {
+    device_name = "/dev/sda1"
+
+    ebs {
+      volume_size = var.runners_root_size
+      volume_type = var.runners_volume_type
+    }
+  }
 
   iam_instance_profile {
     name = aws_iam_instance_profile.docker_machine[0].name
   }
 
   network_interfaces {
-    security_groups = concat([aws_security_group.docker_machine[0].id])
+    security_groups = [aws_security_group.docker_machine[0].id]
+    associate_public_ip_address = !var.runners_use_private_address
   }
+
+  placement {
+    availability_zone = data.aws_availability_zone.runners.name
+  }
+
   tag_specifications {
     resource_type = "instance"
     tags          = local.tags
@@ -361,6 +380,13 @@ resource "aws_launch_template" "gitlab_runners" {
   }
 
   tags = local.tags
+
+  metadata_options {
+    http_endpoint               = "enabled"
+    http_tokens                 = var.docker_machine_instance_metadata_options.http_tokens
+    http_put_response_hop_limit = var.docker_machine_instance_metadata_options.http_put_response_hop_limit
+    instance_metadata_tags      = "enabled"
+  }
 
   lifecycle {
     create_before_destroy = true

--- a/main.tf
+++ b/main.tf
@@ -344,6 +344,10 @@ resource "aws_launch_template" "gitlab_runners" {
   instance_type          = var.docker_machine_instance_types[0] # it will be overrided by the fleet
   update_default_version = true
 
+  iam_instance_profile {
+    name = aws_iam_instance_profile.docker_machine[0].name
+  }
+
   network_interfaces {
     security_groups = concat([aws_security_group.docker_machine[0].id])
   }

--- a/main.tf
+++ b/main.tf
@@ -94,7 +94,7 @@ locals {
       runners_subnet_ids                = length(var.subnet_ids) > 0 ? var.subnet_ids : length(var.subnet_id) > 0 ? [var.subnet_id] : [var.subnet_id_runners]
       runners_aws_zone                  = data.aws_availability_zone.runners.name_suffix
       runners_instance_type             = var.docker_machine_instance_type
-      runners_instance_types            = length(var.docker_machine_instance_types) > 0 ?  var.docker_machine_instance_types : [var.docker_machine_instance_type]
+      runners_instance_types            = length(var.docker_machine_instance_types) > 0 ? var.docker_machine_instance_types : [var.docker_machine_instance_type]
       runners_spot_price_bid            = var.docker_machine_spot_price_bid == "on-demand-price" || var.docker_machine_spot_price_bid == null ? "" : var.docker_machine_spot_price_bid
       runners_ami                       = var.runners_executor == "docker+machine" ? data.aws_ami.docker-machine[0].id : ""
       runners_security_group_name       = var.runners_executor == "docker+machine" ? aws_security_group.docker_machine[0].name : ""
@@ -327,7 +327,7 @@ resource "aws_launch_template" "gitlab_runner_instance" {
 }
 
 resource "aws_key_pair" "fleet_key" {
-  count      = var.use_fleet == true && var.runners_executor == "docker+machine" ? 1 : 0
+  count = var.use_fleet == true && var.runners_executor == "docker+machine" ? 1 : 0
 
   key_name   = var.key_pair_name
   public_key = var.public_key
@@ -336,7 +336,7 @@ resource "aws_key_pair" "fleet_key" {
 resource "aws_launch_template" "gitlab_runners" {
   # checkov:skip=CKV_AWS_88:User can decide to add a public IP.
   # checkov:skip=CKV_AWS_79:User can decide to enable Metadata service V2. V2 is the default.
-  count = var.use_fleet == true && var.runners_executor == "docker+machine" ? 1 : 0
+  count       = var.use_fleet == true && var.runners_executor == "docker+machine" ? 1 : 0
   name_prefix = "${local.name_runner_agent_instance}-worker-"
 
   key_name               = aws_key_pair.fleet_key[0].key_name

--- a/main.tf
+++ b/main.tf
@@ -345,7 +345,7 @@ resource "aws_launch_template" "gitlab_runners" {
   update_default_version = true
 
   network_interfaces {
-    security_groups             = concat([aws_security_group.docker_machine[0].id])
+    security_groups = concat([aws_security_group.docker_machine[0].id])
   }
   tag_specifications {
     resource_type = "instance"

--- a/main.tf
+++ b/main.tf
@@ -366,10 +366,6 @@ resource "aws_launch_template" "gitlab_runners" {
     associate_public_ip_address = !var.runners_use_private_address
   }
 
-  placement {
-    availability_zone = data.aws_availability_zone.runners.name
-  }
-
   tag_specifications {
     resource_type = "instance"
     tags          = local.tags
@@ -382,7 +378,6 @@ resource "aws_launch_template" "gitlab_runners" {
   tags = local.tags
 
   metadata_options {
-    http_endpoint               = "enabled"
     http_tokens                 = var.docker_machine_instance_metadata_options.http_tokens
     http_put_response_hop_limit = var.docker_machine_instance_metadata_options.http_put_response_hop_limit
     instance_metadata_tags      = "enabled"

--- a/policies/instance-docker-machine-policy.json
+++ b/policies/instance-docker-machine-policy.json
@@ -1,34 +1,34 @@
 {
-  "Version": "2012-10-17",
-  "Statement": [
-    {
-      "Action": [
-        "ec2:DescribeKeyPairs",
-        "ec2:TerminateInstances",
-        "ec2:StopInstances",
-        "ec2:StartInstances",
-        "ec2:RunInstances",
-        "ec2:RebootInstances",
-        "ec2:CreateKeyPair",
-        "ec2:DeleteKeyPair",
-        "ec2:ImportKeyPair",
-        "ec2:Describe*",
-        "ec2:CreateTags",
-        "ec2:RequestSpotInstances",
-        "ec2:CancelSpotInstanceRequests",
-        "ec2:DescribeSubnets",
-        "ec2:AssociateIamInstanceProfile",
-        "ec2:CreateFleet"
-      ],
-      "Effect": "Allow",
-      "Resource": "*"
-    },
-    {
-      "Action": [
-        "iam:PassRole"
-      ],
-      "Effect": "Allow",
-      "Resource": "${docker_machine_role_arn}"
-    }
-  ]
-}
+    "Version": "2012-10-17",
+    "Statement": [
+      {
+        "Action": [
+          "ec2:DescribeKeyPairs",
+          "ec2:TerminateInstances",
+          "ec2:StopInstances",
+          "ec2:StartInstances",
+          "ec2:RunInstances",
+          "ec2:RebootInstances",
+          "ec2:CreateKeyPair",
+          "ec2:DeleteKeyPair",
+          "ec2:ImportKeyPair",
+          "ec2:Describe*",
+          "ec2:CreateTags",
+          "ec2:RequestSpotInstances",
+          "ec2:CancelSpotInstanceRequests",
+          "ec2:DescribeSubnets",
+          "ec2:AssociateIamInstanceProfile",
+          "ec2:CreateFleet"
+        ],
+        "Effect": "Allow",
+        "Resource": "*"
+      },
+      {
+        "Action": [
+          "iam:PassRole"
+        ],
+        "Effect": "Allow",
+        "Resource": "${docker_machine_role_arn}"
+      }
+    ]
+  }

--- a/policies/instance-docker-machine-policy.json
+++ b/policies/instance-docker-machine-policy.json
@@ -1,33 +1,34 @@
 {
-    "Version": "2012-10-17",
-    "Statement": [
-      {
-        "Action": [
-          "ec2:DescribeKeyPairs",
-          "ec2:TerminateInstances",
-          "ec2:StopInstances",
-          "ec2:StartInstances",
-          "ec2:RunInstances",
-          "ec2:RebootInstances",
-          "ec2:CreateKeyPair",
-          "ec2:DeleteKeyPair",
-          "ec2:ImportKeyPair",
-          "ec2:Describe*",
-          "ec2:CreateTags",
-          "ec2:RequestSpotInstances",
-          "ec2:CancelSpotInstanceRequests",
-          "ec2:DescribeSubnets",
-          "ec2:AssociateIamInstanceProfile"
-        ],
-        "Effect": "Allow",
-        "Resource": "*"
-      },
-      {
-        "Action": [
-          "iam:PassRole"
-        ],
-        "Effect": "Allow",
-        "Resource": "${docker_machine_role_arn}"
-      }
-    ]
-  }
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Action": [
+        "ec2:DescribeKeyPairs",
+        "ec2:TerminateInstances",
+        "ec2:StopInstances",
+        "ec2:StartInstances",
+        "ec2:RunInstances",
+        "ec2:RebootInstances",
+        "ec2:CreateKeyPair",
+        "ec2:DeleteKeyPair",
+        "ec2:ImportKeyPair",
+        "ec2:Describe*",
+        "ec2:CreateTags",
+        "ec2:RequestSpotInstances",
+        "ec2:CancelSpotInstanceRequests",
+        "ec2:DescribeSubnets",
+        "ec2:AssociateIamInstanceProfile",
+        "ec2:CreateFleet"
+      ],
+      "Effect": "Allow",
+      "Resource": "*"
+    },
+    {
+      "Action": [
+        "iam:PassRole"
+      ],
+      "Effect": "Allow",
+      "Resource": "${docker_machine_role_arn}"
+    }
+  ]
+}

--- a/template/gitlab-runner.tftpl
+++ b/template/gitlab-runner.tftpl
@@ -48,18 +48,12 @@ fi
 
 sed -i.bak s/__REPLACED_BY_USER_DATA__/$token/g /etc/gitlab-runner/config.toml
 
-if [[ "${use_fleet} == "true ]]
+if [[ "${use_fleet}" == "true" ]]
 then
-  if [[ "${secure_parameter_store_runner_private_key}" != "" ]]
-  then
-    echo "$(aws ssm get-parameters --names "${secure_parameter_store_runner_private_key}" --with-decryption --region "${secure_parameter_store_region}" | jq -r ".Parameters | .[0] | .Value")" > /root/.ssh/id_rsa
-  else
-    echo "${private_key}" > /root/.ssh/id_rsa
-  fi
-
+  echo "$(aws ssm get-parameters --names "${secure_parameter_store_runner_private_key}" --with-decryption --region "${secure_parameter_store_region}" | jq -r ".Parameters | .[0] | .Value")" > /root/.ssh/id_rsa
   echo "${public_key}" > /root/.ssh/id_rsa.pub
+
   chmod 600 /root/.ssh/id_rsa
-  chmod 600 /root/.ssh/id_rsa.pub
 fi
 
 ssm_sentry_dsn=$(aws ssm get-parameters --names "${secure_parameter_store_runner_sentry_dsn}" --with-decryption --region "${secure_parameter_store_region}" | jq -r ".Parameters | .[0] | .Value")

--- a/template/gitlab-runner.tftpl
+++ b/template/gitlab-runner.tftpl
@@ -48,6 +48,20 @@ fi
 
 sed -i.bak s/__REPLACED_BY_USER_DATA__/$token/g /etc/gitlab-runner/config.toml
 
+if [[ "${use_fleet} == "true ]]
+then
+  if [[ "${secure_parameter_store_runner_private_key}" != "" ]]
+  then
+    echo "$(aws ssm get-parameters --names "${secure_parameter_store_runner_private_key}" --with-decryption --region "${secure_parameter_store_region}" | jq -r ".Parameters | .[0] | .Value")" > /root/.ssh/id_rsa
+  else
+    echo "${private_key}" > /root/.ssh/id_rsa
+  fi
+
+  echo "${public_key}" > /root/.ssh/id_rsa.pub
+  chmod 600 /root/.ssh/id_rsa
+  chmod 600 /root/.ssh/id_rsa.pub
+fi
+
 ssm_sentry_dsn=$(aws ssm get-parameters --names "${secure_parameter_store_runner_sentry_dsn}" --with-decryption --region "${secure_parameter_store_region}" | jq -r ".Parameters | .[0] | .Value")
 if [[ "${sentry_dsn}" == "__SENTRY_DSN_REPLACED_BY_USER_DATA__" && "$ssm_sentry_dsn" == "null" ]]
 then

--- a/template/runner-config.tftpl
+++ b/template/runner-config.tftpl
@@ -50,19 +50,19 @@ listen_address = "${prometheus_listen_address}"
     MachineDriver = "amazonec2"
     MachineName = "${docker_machine_name}"
     MachineOptions = [
-      %{ for instance_type in runners_instance_types }
+      %{~ for instance_type in runners_instance_types ~}
       "amazonec2-instance-type=${instance_type}",
-      %{ endfor ~}
+      %{~ endfor ~}
       "amazonec2-region=${aws_region}",
       "amazonec2-zone=${runners_aws_zone}",
       "amazonec2-vpc-id=${runners_vpc_id}",
-      %{ for subnet_id in runners_subnet_ids }
+      %{~ for subnet_id in runners_subnet_ids ~}
       "amazonec2-subnet-id=${subnet_id}",
-      %{ endfor ~}
+      %{~ endfor ~}
       "amazonec2-private-address-only=${runners_use_private_address_only}",
       "amazonec2-use-private-address=${runners_use_private_address}",
       "amazonec2-request-spot-instance=${runners_request_spot_instance}",
-      %{ if runners_spot_price_bid != ""}"amazonec2-spot-price=${runners_spot_price_bid}",%{ endif ~}
+      %{~ if runners_spot_price_bid != "" ~}"amazonec2-spot-price=${runners_spot_price_bid}",%{~ endif ~}
       "amazonec2-security-group=${runners_security_group_name}",
       "amazonec2-tags=${runners_tags},__PARENT_TAG__",
       "amazonec2-use-ebs-optimized-instance=${runners_ebs_optimized}",
@@ -70,13 +70,13 @@ listen_address = "${prometheus_listen_address}"
       "amazonec2-iam-instance-profile=%{ if runners_iam_instance_profile_name != "" }${runners_iam_instance_profile_name}%{ else }${runners_instance_profile}%{ endif ~}",
       "amazonec2-root-size=${runners_root_size}",
       "amazonec2-volume-type=${runners_volume_type}",
-      "amazonec2-userdata=%{ if runners_userdata != "" }/etc/gitlab-runner/runners_userdata.sh%{ endif ~}",
+      "amazonec2-userdata=%{~ if runners_userdata != "" ~}/etc/gitlab-runner/runners_userdata.sh%{~ endif ~}",
       "amazonec2-ami=${runners_ami}"
-      %{ if use_fleet == true}
+      %{~ if use_fleet == true ~}
       ,"amazonec2-ssh-keypath=/root/.ssh/id_rsa",
       "amazonec2-use-fleet=${use_fleet}",
       "amazonec2-launch-template=${launch_template}"
-      %{ endif ~}
+      %{~ endif ~}
       ${docker_machine_options}
     ]
 

--- a/template/runner-config.tftpl
+++ b/template/runner-config.tftpl
@@ -71,8 +71,12 @@ listen_address = "${prometheus_listen_address}"
       "amazonec2-root-size=${runners_root_size}",
       "amazonec2-volume-type=${runners_volume_type}",
       "amazonec2-userdata=%{ if runners_userdata != "" }/etc/gitlab-runner/runners_userdata.sh%{ endif ~}",
-      "amazonec2-ami=${runners_ami}",
-      %{ if use_fleet == true}"amazonec2-ssh-keypath=/root/.ssh/id_rsa","amazonec2-use-fleet=${use_fleet}","amazonec2-launch-template=${launch_template}"%{ endif ~}
+      "amazonec2-ami=${runners_ami}"
+      %{ if use_fleet == true}
+      ,"amazonec2-ssh-keypath=/root/.ssh/id_rsa",
+      "amazonec2-use-fleet=${use_fleet}",
+      "amazonec2-launch-template=${launch_template}"
+      %{ endif ~}
       ${docker_machine_options}
     ]
 

--- a/template/runner-config.tftpl
+++ b/template/runner-config.tftpl
@@ -50,11 +50,15 @@ listen_address = "${prometheus_listen_address}"
     MachineDriver = "amazonec2"
     MachineName = "${docker_machine_name}"
     MachineOptions = [
-      "amazonec2-instance-type=${runners_instance_type}",
+      %{ for instance_type in runners_instance_types }
+      "amazonec2-instance-type=${instance_type}",
+      %{ endfor ~}
       "amazonec2-region=${aws_region}",
       "amazonec2-zone=${runners_aws_zone}",
       "amazonec2-vpc-id=${runners_vpc_id}",
-      "amazonec2-subnet-id=${runners_subnet_id}",
+      %{ for subnet_id in runners_subnet_ids }
+      "amazonec2-subnet-id=${subnet_id}",
+      %{ endfor ~}
       "amazonec2-private-address-only=${runners_use_private_address_only}",
       "amazonec2-use-private-address=${runners_use_private_address}",
       "amazonec2-request-spot-instance=${runners_request_spot_instance}",
@@ -67,7 +71,8 @@ listen_address = "${prometheus_listen_address}"
       "amazonec2-root-size=${runners_root_size}",
       "amazonec2-volume-type=${runners_volume_type}",
       "amazonec2-userdata=%{ if runners_userdata != "" }/etc/gitlab-runner/runners_userdata.sh%{ endif ~}",
-      "amazonec2-ami=${runners_ami}"
+      "amazonec2-ami=${runners_ami}",
+      %{ if use_fleet == true}"amazonec2-ssh-keypath=/root/.ssh/id_rsa","amazonec2-use-fleet=${use_fleet}","amazonec2-launch-template=${launch_template}"%{ endif ~}
       ${docker_machine_options}
     ]
 

--- a/variables.tf
+++ b/variables.tf
@@ -32,7 +32,7 @@ variable "subnet_id" {
 }
 
 variable "subnet_ids" {
-  description = "Subnet ids used for executors when the fleet mode is enabled. Must belong to the VPC specified above."
+  description = "First subnet in the list is used for the runner. Complete list is used for executors when the fleet mode is enabled. Must belong to the VPC specified above."
   type        = list(string)
   default     = []
 }
@@ -50,7 +50,7 @@ variable "metrics_autoscaling" {
 }
 
 variable "key_pair_name" {
-  description = "The name of the key pair to use for the runner agent instance. This variable is only supported when use_fleet is set to true."
+  description = "The name of the key pair used by the runner to connect to the docker-machine executors."
   type        = string
   default     = "fleet-key"
 }
@@ -616,18 +616,10 @@ variable "gitlab_runner_registration_config" {
 }
 
 variable "public_key" {
-  description = "The SSH public key used to access the Gitlab runner agent instances. This variable is supported only when use_fleet is set to true."
+  description = "The SSH public key used by the runner to connect to the docker-machine executors. This variable is supported only when use_fleet is set to true."
   type        = string
   default     = ""
 }
-
-variable "private_key" {
-  description = "The SSH priate key used to access the Gitlab runner agent instances. This variable is supported only when use_fleet is set to true and secure_parameter_store_private_key is unset."
-  type        = string
-  #sensitive   = true
-  default     = ""
-}
-
 
 variable "secure_parameter_store_runner_token_key" {
   description = "The key name used store the Gitlab runner token in Secure Parameter Store"

--- a/variables.tf
+++ b/variables.tf
@@ -31,6 +31,12 @@ variable "subnet_id" {
   default     = "" # TODO remove as soon as subnet_id_runners and subnet_ids_gitlab_runner are gone. Variable is mandatory now.
 }
 
+variable "subnet_ids" {
+  description = "Subnet ids used for executors when the fleet mode is enabled. Must belong to the VPC specified above."
+  type        = list(string)
+  default     = []
+}
+
 variable "extra_security_group_ids_runner_agent" {
   description = "Optional IDs of extra security groups to apply to the runner agent. This will not apply to the runners spun up when using the docker+machine executor, which is the default."
   type        = list(string)
@@ -41,6 +47,12 @@ variable "metrics_autoscaling" {
   description = "A list of metrics to collect. The allowed values are GroupDesiredCapacity, GroupInServiceCapacity, GroupPendingCapacity, GroupMinSize, GroupMaxSize, GroupInServiceInstances, GroupPendingInstances, GroupStandbyInstances, GroupStandbyCapacity, GroupTerminatingCapacity, GroupTerminatingInstances, GroupTotalCapacity, GroupTotalInstances."
   type        = list(string)
   default     = null
+}
+
+variable "key_pair_name" {
+  description = "The name of the key pair to use for the runner agent instance. This variable is only supported when use_fleet is set to true."
+  type        = string
+  default     = "fleet-key"
 }
 
 variable "instance_type" {
@@ -99,6 +111,12 @@ variable "docker_machine_instance_type" {
   description = "Instance type used for the instances hosting docker-machine."
   type        = string
   default     = "m5.large"
+}
+
+variable "docker_machine_instance_types" {
+  description = "Instance types used for the instances hosting docker-machine. This variable is only supported when use_fleet is set to true."
+  type        = list(string)
+  default     = []
 }
 
 variable "docker_machine_spot_price_bid" {
@@ -597,6 +615,20 @@ variable "gitlab_runner_registration_config" {
   }
 }
 
+variable "public_key" {
+  description = "The SSH public key used to access the Gitlab runner agent instances. This variable is supported only when use_fleet is set to true."
+  type        = string
+  default     = ""
+}
+
+variable "private_key" {
+  description = "The SSH priate key used to access the Gitlab runner agent instances. This variable is supported only when use_fleet is set to true and secure_parameter_store_private_key is unset."
+  type        = string
+  #sensitive   = true
+  default     = ""
+}
+
+
 variable "secure_parameter_store_runner_token_key" {
   description = "The key name used store the Gitlab runner token in Secure Parameter Store"
   type        = string
@@ -607,6 +639,12 @@ variable "secure_parameter_store_runner_sentry_dsn" {
   description = "The Sentry DSN name used to store the Sentry DSN in Secure Parameter Store"
   type        = string
   default     = "sentry-dsn"
+}
+
+variable "secure_parameter_store_runner_private_key" {
+  description = "The key name used to store the Gitlab runner private key in Secure Parameter Store"
+  type        = string
+  default     = ""
 }
 
 variable "enable_manage_gitlab_token" {
@@ -761,6 +799,12 @@ variable "kms_deletion_window_in_days" {
   description = "Key rotation window, set to 0 for no rotation. Only used when `enable_kms` is set to `true`."
   type        = number
   default     = 7
+}
+
+variable "use_fleet" {
+  description = "Use the fleet mode for agents. https://gitlab.com/cki-project/docker-machine/-/blob/v0.16.2-gitlab.19-cki.2/docs/drivers/aws.md#fleet-mode"
+  type        = bool
+  default     = false
 }
 
 variable "enable_eip" {


### PR DESCRIPTION
## Description

The [fork](https://gitlab.com/cki-project/docker-machine/-/tree/v0.16.2-gitlab.19-cki.2) of docker-machine used in this module has released a version that supports [AWS Spot Fleet](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/spot-fleet.html) 3 months ago.

In our case, spot fleets are useful when using spot instances because it fixes the issue when there is no capacity available for a certain instance type in a certain AZ. With spot fleets, we can use multiple instance types and AZ so when there is no capacity on one instance type, AWS will take the next instance type and so on.

This fixes issues [#76](https://github.com/cattle-ops/terraform-aws-gitlab-runner/issues/76) [#435](https://github.com/cattle-ops/terraform-aws-gitlab-runner/issues/435) [#77](https://github.com/cattle-ops/terraform-aws-gitlab-runner/issues/77) and [#474](https://github.com/cattle-ops/terraform-aws-gitlab-runner/issues/474)

## Migrations required
NO our solution is backward compatible so if you don't plan to use spot fleets, no migration is required.
YES if you want to use spot fleets you will have to do the following changes:
`docker_machine_instance_type` to `docker_machine_instance_types`
`subnet_id` to `subnet_ids`

You also have to put these 4 new parameters:
`use_fleet` `public_key` `secure_parameter_store_runner_private_key` and `key_pair_name` 

## Verification

```hcl
  docker_machine_instance_types = ["r5a.xlarge", "r5.xlarge", "r5ad.xlarge", "r5d.xlarge", "m5a.2xlarge"]
  use_fleet                     = true

  public_key                                = "<ssh-public-key>"
  secure_parameter_store_runner_private_key = "<parameter-store-name>"
  key_pair_name                             = "<key-pair-name>"
```
We are using this solution in production for a week now with 150+ developers and over 20 000 jobs a day without any issue for now.