### PR TITLE
Support gitlab 16

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -69,13 +69,18 @@ locals {
       secure_parameter_store_runner_token_key                      = local.secure_parameter_store_runner_token_key
       secure_parameter_store_runner_sentry_dsn                     = local.secure_parameter_store_runner_sentry_dsn
       secure_parameter_store_gitlab_runner_registration_token_name = var.secure_parameter_store_gitlab_runner_registration_token_name
+      secure_parameter_store_gitlab_token_name                     = var.secure_parameter_store_gitlab_token_name
       secure_parameter_store_region                                = var.aws_region
       gitlab_runner_registration_token                             = lookup(var.gitlab_runner_registration_config, "registration_token", "__GITLAB_REGISTRATION_TOKEN_FROM_SSM__")
+      gitlab_token                                                 = var.gitlab_token != "" ? var.gitlab_token : "__GITLAB_TOKEN_FROM_SSM__"
       gitlab_runner_description                                    = var.gitlab_runner_registration_config["description"]
       gitlab_runner_tag_list                                       = var.gitlab_runner_registration_config["tag_list"]
       gitlab_runner_locked_to_project                              = var.gitlab_runner_registration_config["locked_to_project"]
       gitlab_runner_run_untagged                                   = var.gitlab_runner_registration_config["run_untagged"]
       gitlab_runner_maximum_timeout                                = var.gitlab_runner_registration_config["maximum_timeout"]
+      gitlab_runner_type                                           = var.gitlab_runner_registration_config["type"]
+      gitlab_runner_group_id                                       = lookup(var.gitlab_runner_registration_config, "group_id", "")
+      gitlab_runner_project_id                                     = lookup(var.gitlab_runner_registration_config, "project_id", "")
       gitlab_runner_access_level                                   = lookup(var.gitlab_runner_registration_config, "access_level", "not_protected")
       sentry_dsn                                                   = var.sentry_dsn
       public_key                                                   = var.use_fleet == true ? tls_private_key.fleet[0].public_key_openssh : ""

--- a/outputs.tf
+++ b/outputs.tf
@@ -55,5 +55,5 @@ output "runner_launch_template_name" {
 
 output "runner_user_data" {
   description = "(Deprecated) The user data of the Gitlab Runner Agent's launch template. Set `var.debug.output_runner_user_data_to_file` to true to write `user_data.sh`."
-  value       = local.template_user_data
+  value       = nonsensitive(local.template_user_data)
 }

--- a/template/gitlab-runner.tftpl
+++ b/template/gitlab-runner.tftpl
@@ -47,8 +47,18 @@ fi
 
 if [[ "${runners_token}" == "__REPLACED_BY_USER_DATA__" && "$token" == "null" ]] || [[ "$valid_token" == "false" ]]
 then
-  if [[ ! "${gitlab_runner_version}" < "16.0.0" ]]
+  if [[ "${gitlab_runner_version}" < "16.0.0" ]]
   then
+    token=$(curl ${curl_cacert} --request POST -L "${runners_gitlab_url}/api/v4/runners" \
+      --form "token=$gitlab_runner_registration_token" \
+      --form "tag_list=${gitlab_runner_tag_list}" \
+      --form "description=${gitlab_runner_description}" \
+      --form "locked=${gitlab_runner_locked_to_project}" \
+      --form "run_untagged=${gitlab_runner_run_untagged}" \
+      --form "maximum_timeout=${gitlab_runner_maximum_timeout}" \
+      --form "access_level=${gitlab_runner_access_level}" \
+      | jq -r .token)
+  else
     runner_type_param=""
     if [ "${gitlab_runner_type}" = "group_type" ]; then
       runner_type_param='--form group_id=${gitlab_runner_group_id}'
@@ -67,16 +77,6 @@ then
       $runner_type_param \
       --form "access_level=${gitlab_runner_access_level}" \
       | jq -r '.token')
-  else
-    token=$(curl ${curl_cacert} --request POST -L "${runners_gitlab_url}/api/v4/runners" \
-      --form "token=$gitlab_runner_registration_token" \
-      --form "tag_list=${gitlab_runner_tag_list}" \
-      --form "description=${gitlab_runner_description}" \
-      --form "locked=${gitlab_runner_locked_to_project}" \
-      --form "run_untagged=${gitlab_runner_run_untagged}" \
-      --form "maximum_timeout=${gitlab_runner_maximum_timeout}" \
-      --form "access_level=${gitlab_runner_access_level}" \
-      | jq -r .token)
   fi
   aws ssm put-parameter --overwrite --type SecureString  --name "${secure_parameter_store_runner_token_key}" --value="$token" --region "${secure_parameter_store_region}"
 fi

--- a/template/gitlab-runner.tftpl
+++ b/template/gitlab-runner.tftpl
@@ -34,22 +34,50 @@ fi
 
 gitlab_runner_registration_token=${gitlab_runner_registration_token}
 # fetch registration token from SSM
-if [[ "$gitlab_runner_registration_token" == "__GITLAB_REGISTRATION_TOKEN_FROM_SSM__" ]]
+if [[ "$gitlab_runner_registration_token" == "__GITLAB_REGISTRATION_TOKEN_FROM_SSM__" ]] && [[ "${gitlab_runner_version}" < "16.0.0" ]]
 then
     gitlab_runner_registration_token=$(aws ssm get-parameter --name "${secure_parameter_store_gitlab_runner_registration_token_name}" --with-decryption --region "${secure_parameter_store_region}" | jq -r ".Parameter | .Value")
 fi
 
+# fetch gitlab token from SSM
+if [[ "${gitlab_token}" == "__GITLAB_TOKEN_FROM_SSM__" ]]
+then
+    gitlab_token=$(aws ssm get-parameter --name "${secure_parameter_store_gitlab_token_name}" --with-decryption --region "${secure_parameter_store_region}" | jq -r ".Parameter | .Value")
+fi
+
 if [[ "${runners_token}" == "__REPLACED_BY_USER_DATA__" && "$token" == "null" ]] || [[ "$valid_token" == "false" ]]
 then
-  token=$(curl ${curl_cacert} --request POST -L "${runners_gitlab_url}/api/v4/runners" \
-    --form "token=$gitlab_runner_registration_token" \
-    --form "tag_list=${gitlab_runner_tag_list}" \
-    --form "description=${gitlab_runner_description}" \
-    --form "locked=${gitlab_runner_locked_to_project}" \
-    --form "run_untagged=${gitlab_runner_run_untagged}" \
-    --form "maximum_timeout=${gitlab_runner_maximum_timeout}" \
-    --form "access_level=${gitlab_runner_access_level}" \
-    | jq -r .token)
+  if [[ ! "${gitlab_runner_version}" < "16.0.0" ]]
+  then
+    runner_type_param=""
+    if [ "${gitlab_runner_type}" = "group_type" ]; then
+      runner_type_param='--form group_id=${gitlab_runner_group_id}'
+    elif [ "${gitlab_runner_type}" = "project_type" ]; then
+      runner_type_param='--form project_id=${gitlab_runner_project_id}'
+    fi
+
+    token=$(curl ${curl_cacert} --request POST -L "${runners_gitlab_url}/api/v4/user/runners" \
+      --header "private-token: $gitlab_token" \
+      --form "tag_list=${gitlab_runner_tag_list}" \
+      --form "description=${gitlab_runner_description}" \
+      --form "locked=${gitlab_runner_locked_to_project}" \
+      --form "run_untagged=${gitlab_runner_run_untagged}" \
+      --form "maximum_timeout=${gitlab_runner_maximum_timeout}" \
+      --form "runner_type=${gitlab_runner_type}" \
+      $runner_type_param \
+      --form "access_level=${gitlab_runner_access_level}" \
+      | jq -r '.token')
+  else
+    token=$(curl ${curl_cacert} --request POST -L "${runners_gitlab_url}/api/v4/runners" \
+      --form "token=$gitlab_runner_registration_token" \
+      --form "tag_list=${gitlab_runner_tag_list}" \
+      --form "description=${gitlab_runner_description}" \
+      --form "locked=${gitlab_runner_locked_to_project}" \
+      --form "run_untagged=${gitlab_runner_run_untagged}" \
+      --form "maximum_timeout=${gitlab_runner_maximum_timeout}" \
+      --form "access_level=${gitlab_runner_access_level}" \
+      | jq -r .token)
+  fi
   aws ssm put-parameter --overwrite --type SecureString  --name "${secure_parameter_store_runner_token_key}" --value="$token" --region "${secure_parameter_store_region}"
 fi
 

--- a/template/gitlab-runner.tftpl
+++ b/template/gitlab-runner.tftpl
@@ -34,7 +34,7 @@ fi
 
 gitlab_runner_registration_token=${gitlab_runner_registration_token}
 # fetch registration token from SSM
-if [[ "$gitlab_runner_registration_token" == "__GITLAB_REGISTRATION_TOKEN_FROM_SSM__" ]] && [[ "${gitlab_runner_version}" < "16.0.0" ]]
+if [[ "$gitlab_runner_registration_token" == "__GITLAB_REGISTRATION_TOKEN_FROM_SSM__" ]]
 then
     gitlab_runner_registration_token=$(aws ssm get-parameter --name "${secure_parameter_store_gitlab_runner_registration_token_name}" --with-decryption --region "${secure_parameter_store_region}" | jq -r ".Parameter | .Value")
 fi

--- a/variables.tf
+++ b/variables.tf
@@ -612,6 +612,9 @@ variable "gitlab_runner_registration_config" {
 
   default = {
     registration_token = ""
+    type               = ""
+    group_id           = "" # mandatory if type is group_type
+    project_id         = "" # mandatory if type is project_type
     tag_list           = ""
     description        = ""
     locked_to_project  = ""
@@ -650,6 +653,18 @@ variable "enable_manage_gitlab_token" {
     condition     = anytrue([var.enable_manage_gitlab_token == null])
     error_message = "Deprecated, this variable is no longer in use and can be removed."
   }
+}
+
+variable "gitlab_token" {
+  description = "GitLab admin token used by the runners in order to register themselves if gitlab_runner_version >= 16.0.0. If not provided the token will be read from the SSM parameter store."
+  type        = string
+  default     = ""
+}
+
+variable "secure_parameter_store_gitlab_token_name" {
+  description = "The name of the SSM parameter to read the GitLab token from."
+  type        = string
+  default     = "gitlab-token"
 }
 
 variable "overrides" {

--- a/variables.tf
+++ b/variables.tf
@@ -612,7 +612,7 @@ variable "gitlab_runner_registration_config" {
 
   default = {
     registration_token = ""
-    type               = ""
+    type               = "" # mandatory if gitlab_runner_version >= 16.0.0
     group_id           = "" # mandatory if type is group_type
     project_id         = "" # mandatory if type is project_type
     tag_list           = ""


### PR DESCRIPTION
## Description

GitLab released a new authentication architecture for their runners since the version 16.0.0. (see https://docs.gitlab.com/ee/architecture/blueprints/runner_tokens). This MR handle this new architecture while maintaining backward compatibility.

## Migrations required

NO, until GitLab removes the old authentication method.

## Verification

I ran this module on a 16.0.1 GitLab.
